### PR TITLE
Added a clear and a display random stat functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ Sets the interval for the carousel to change statistics.
 **Usage: `./stat toggle [total/offline]`**  
 Toggles whether the total or offline players should be shown.
 
+**Usage: `./stat random`**
+Displays a random stat on the scoreboard.
+
+**Usage: `./stat clear`**
+Resets and clears all available stats. This is different from `stat all reset` in that events that have not yet occurred after this command is executed are also removed from the stat list.  
+<strong style="color:red;">A SERVER RESTART IS REQUIRED TO COMPLETE THIS COMMAND, AND WILL CAUSE BASE STAT CATEGORIES TO NOT INCREMENT PROPERLY IF RESTART IS NOT PERFORMED.</strong>
+
 **Usage: `./transferstats`**  
 A utility command used to transfer statistics from v1.0.0 of this addon to v1.1.0. This command is only present in v1.1.0 & v1.1.1, and is removed in future versions.
 

--- a/scripts/src/classes/Event.js
+++ b/scripts/src/classes/Event.js
@@ -12,7 +12,7 @@ class Event {
         this.eventID = eventID;
         this.displayName = displayName;
         this.#dpIdentifier = EVENT_ID_PREFIX + eventID;
-        
+
         if (!world.getDynamicPropertyIds().includes(this.#dpIdentifier)) {
             this.#initializeDynamicProperty();
         }
@@ -32,7 +32,7 @@ class Event {
 
     hasParticipant(player) {
         const data = this.getData();
-        const participantNames = data.participants.map(participant => participant.name)
+        const participantNames = data.participants.map(participant => participant.name);
         return participantNames.includes(player.name);
     }
 
@@ -40,7 +40,7 @@ class Event {
         this.#initializeDynamicProperty();
         Display.update(this);
     }
-    
+
     updateCount(player, count, operation = 'add') {
         const data = this.getData();
         if (!this.hasParticipant(player)) {
@@ -50,7 +50,7 @@ class Event {
             });
         }
         const participant = data.participants.find(participant => participant.name === player.name);
-        
+
         switch (operation) {
             case 'add':
                 participant.score += count;
@@ -64,7 +64,7 @@ class Event {
         world.setDynamicProperty(this.#dpIdentifier, JSON.stringify(data));
         Display.update(this);
     }
-    
+
     getCount(player) {
         const data = this.getData();
         const participant = data.participants.find(participant => participant.name === player.name);
@@ -72,7 +72,7 @@ class Event {
             return 0;
         return participant.score;
     }
-    
+
     getTotal() {
         const data = this.getData();
         let total = 0;

--- a/scripts/src/classes/EventManager.js
+++ b/scripts/src/classes/EventManager.js
@@ -21,7 +21,7 @@ class EventManager {
             this.eventsToRegister.push({ eventID, displayName, setupCallback });
         }
     }
-    
+
     getEventIDs() {
         return BulkDP.load(this.EVENT_LIST_ID);
     }
@@ -39,7 +39,7 @@ class EventManager {
     isRegistered(eventID) {
         return this.events[eventID] !== undefined;
     }
-    
+
     increment(eventID, player) {
         if (!this.exists(eventID))
             throw new Error(`[Stats] Could not increment. Event '${eventID}' not found.`);
@@ -76,6 +76,16 @@ class EventManager {
         }
     }
 
+    /**
+     * not only reset all events, but also clear the event list
+     */
+    clear() {
+        this.resetAll(); // must be called before clearing the event list
+        // reset event list.. because of how events immediately register upon file import the easiest less error prone way to to apply a full clear is
+        // to restart the server after running this command
+        BulkDP.save(this.EVENT_LIST_ID, []);
+    }
+
     validateEventID(eventID) {
         if (this.isRegistered(eventID)) {
             return true;
@@ -83,7 +93,7 @@ class EventManager {
             const displayName = JSON.parse(world.getDynamicProperty(EVENT_ID_PREFIX + eventID)).displayName;
             if (!displayName)
                 return false;
-            this.registerEvent(eventID, displayName, () => {});
+            this.registerEvent(eventID, displayName, () => { });
             return true;
         } else {
             return false;

--- a/scripts/src/commands/stat.js
+++ b/scripts/src/commands/stat.js
@@ -28,8 +28,8 @@ const statCommand = new Command({
         { usage: 'stat carousel list', description: { text: 'Lists all statistics in the carousel.' } },
         { usage: 'stat carousel interval [seconds]', description: { text: 'Sets the interval for the statistic carousel.' } },
         { usage: 'stat toggle [total/offline]', description: { text: 'Toggles whether the total field or offline players should be shown.' } },
-        { usage: 'stat ' + CMD_CLEAR, description: { text: 'Clears all statistics from the stat list. THIS COMMAND REQUIRES A SERVER RESTART TO FULLY TAKE AFFECT.' } },
-        { usage: 'stat ' + CMD_RANDOM, description: { text: 'Displays a random stat on the scoreboard.' } }
+        { usage: 'stat clear', description: { text: 'Clears all statistics from the stat list. THIS COMMAND REQUIRES A SERVER RESTART TO FULLY TAKE AFFECT.' } },
+        { usage: 'stat random', description: { text: 'Displays a random stat on the scoreboard.' } }
     ]
 });
 extension.addCommand(statCommand);
@@ -71,10 +71,10 @@ function statCommandCallback(sender, args) {
         } else {
             sender.sendMessage('§cFailed to set the statistics display.');
         }
-    } else if (argOne == CMD_CLEAR) {
+    } else if (argOne == 'clear') {
         eventManager.clear();
         sender.sendMessage('§cMINECRAFT SERVER RESTART REQUIRED.');
-    } else if (argOne == CMD_RANDOM) {
+    } else if (argOne == 'random') {
         const idList = eventManager.getEventIDs();
         if (idList != null && idList.length > 0) {
             // best rand option available afaik for javascript api

--- a/scripts/src/commands/stat.js
+++ b/scripts/src/commands/stat.js
@@ -4,9 +4,6 @@ import eventManager from 'src/classes/EventManager';
 import Display from 'src/classes/Display';
 import Carousel from 'src/classes/Carousel';
 
-const CMD_CLEAR = 'clear';
-const CMD_RANDOM = 'random';
-
 const statCommand = new Command({
     name: 'stat',
     description: { text: 'Toggles custom statistics in the world\'s scoreboard.' },


### PR DESCRIPTION
The clear command requires a server restart. That was the best approach in my oppinion for a command that should be used pretty in-frequently. It requires this because of how the events self register on import. Leave me suggestions if this is not ideal.